### PR TITLE
Move autoLogin guard to the right place

### DIFF
--- a/lib/controllers/register.js
+++ b/lib/controllers/register.js
@@ -208,11 +208,11 @@ module.exports = function (req, res, next) {
                         return helpers.writeJsonError(res, err);
                       }
 
-                      if (config.web.register.emailVerificationRequired && autoLogin !== false) {
+                      if (config.web.register.emailVerificationRequired) {
                         emailVerificationHandler(account);
                       }
 
-                      if (config.web.register.autoLogin) {
+                      if (config.web.register.autoLogin && autoLogin !== false) {
                         var options = {
                           username: req.body.email,
                           password: req.body.password


### PR DESCRIPTION
Regression introduced in https://github.com/CSNW/express-stormpath/pull/4/commits/baeb1a5ff55c364278 which causes the `autoLogin` parameter to not have an effect.